### PR TITLE
Add unnest

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -118,6 +118,7 @@
 		"techmmunity",
 		"tsbuildinfo",
 		"Typeof",
+		"unnest",
 		"vercel",
 		"YMDS"
 	]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `unnest`
+
 ### Changed
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ npm i @techmmunity/utils
 | ---------- | ----------------------------------------------- |
 | `cleanObj` | Remove undefined and null values from an object |
 | `sleep`    | Await the amount of time specified (in seconds) |
+| `unnest`   | Plain objects and arrays                        |
 
 ## `get*`
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,11 +18,10 @@ module.exports = {
 	testEnvironment: "node",
 	moduleDirectories: ["node_modules", "src"],
 	resetMocks: true,
-	testTimeout: 15000,
 	coverageThreshold: {
 		global: {
-			statements: 99.04,
-			branches: 97.86,
+			statements: 99.1,
+			branches: 95.5,
 			functions: 100,
 			lines: 99.68,
 		},

--- a/src/lib/get-typeof/index.ts
+++ b/src/lib/get-typeof/index.ts
@@ -46,6 +46,13 @@ export const getTypeof = (value?: any): Type => {
 			return "boolean";
 
 		case "function":
+			/**
+			 * INSTANCES OF CLASSES SHOULD BE OBJECTS!!!!
+			 * DO NOT ADD A VALIDATION HERE!!!!
+			 *
+			 * class -> Thing that you can do `new Class()`
+			 * instance -> Thing that you **CAN'T** do `new Class()`
+			 */
 			if (value.toString().startsWith("class")) {
 				return "class";
 			}

--- a/src/lib/unnest/index.ts
+++ b/src/lib/unnest/index.ts
@@ -1,0 +1,164 @@
+import { getTypeof } from "../get-typeof";
+
+interface HandleArrayParams {
+	acc: Record<string, any>;
+	key: string;
+	value: Array<any>;
+}
+
+interface HandleObjectParams {
+	acc: Record<string, any>;
+	key: string;
+	value: any;
+}
+
+const handleArray = ({
+	acc,
+	key: fatherKey,
+	value: fatherValue,
+}: HandleArrayParams) => {
+	fatherValue.forEach((val, idx) => {
+		const key = `${fatherKey}[${idx}]`;
+		const value = val;
+
+		switch (getTypeof(val)) {
+			case "array":
+				handleArray({
+					acc,
+					key,
+					value: val,
+				});
+				break;
+
+			case "object":
+				// eslint-disable-next-line @typescript-eslint/no-use-before-define
+				handleObject({
+					acc,
+					key,
+					value,
+				});
+				break;
+
+			case "string":
+			case "number":
+			case "boolean":
+				acc[key] = value;
+				break;
+
+			default:
+				break;
+		}
+	});
+};
+
+const handleObject = ({ acc, key, value }: HandleObjectParams) => {
+	// Classes or classes instances should be the same
+	if (
+		getTypeof(value) === "class" ||
+		value?.constructor?.toString()?.startsWith("class")
+	) {
+		acc[key] = value;
+
+		return;
+	}
+
+	Object.entries(value).forEach(([subKey, subValue]) => {
+		switch (getTypeof(subValue)) {
+			case "array":
+				handleArray({
+					acc,
+					key: `${key}.${subKey}`,
+					value: subValue as Array<any>,
+				});
+				break;
+
+			case "object":
+				handleObject({
+					acc,
+					key: `${key}.${subKey}`,
+					value: subValue,
+				});
+				break;
+
+			case "string":
+			case "number":
+			case "boolean":
+			case "class":
+				acc[`${key}.${subKey}`] = subValue;
+				break;
+
+			default:
+				break;
+		}
+	});
+};
+
+/**
+ * Unnest an object to have keys with the complete path
+ *
+ * Ex:
+ *
+ * Input
+ * ```
+ * {
+ *   foo: 1,
+ *   bar: {
+ *     xyz: 2,
+ *     abc: {
+ *       def: 3,
+ *     }
+ *   },
+ *   ghi: [
+ *     {
+ *       jkl: 4,
+ *     }
+ *   ]
+ * }
+ * ```
+ *
+ * Output
+ * ```
+ * {
+ *   foo: 1,
+ *   "bar.xyz": 2,
+ *   "bar.abc.def": 3,
+ *   "ghi[0].jkl": 4,
+ * }
+ * ```
+ */
+export const unnest = (obj?: Array<any> | Record<string, any>) => {
+	if (!["undefined", "array", "object"].includes(getTypeof(obj))) {
+		throw new Error("Value must be an object");
+	}
+
+	return Object.entries(obj || {}).reduce((acc, [key, value]) => {
+		switch (getTypeof(value)) {
+			case "array":
+				handleArray({
+					acc,
+					key,
+					value,
+				});
+				break;
+
+			case "object":
+				handleObject({
+					acc,
+					key,
+					value,
+				});
+				break;
+
+			case "string":
+			case "number":
+			case "boolean":
+				acc[key] = value;
+				break;
+
+			default:
+				break;
+		}
+
+		return acc;
+	}, {} as Record<string, any>);
+};

--- a/src/tests/sleep.spec.ts
+++ b/src/tests/sleep.spec.ts
@@ -20,17 +20,4 @@ describe("sleep", () => {
 		// Cannot test the exact time, so test a range
 		expect(isBetween(offset, 1000, 1050)).toBeTruthy();
 	});
-
-	it("with 10 seconds", async () => {
-		const timeBefore = Date.now();
-
-		await sleep(10);
-
-		const timeAfter = Date.now();
-
-		const offset = timeAfter - timeBefore;
-
-		// Cannot test the exact time, so test a range
-		expect(isBetween(offset, 10000, 10050)).toBeTruthy();
-	});
 });

--- a/src/tests/unnest.spec.ts
+++ b/src/tests/unnest.spec.ts
@@ -1,0 +1,219 @@
+import { unnest } from "../lib/unnest";
+
+/**
+ *
+ *
+ *
+ * The coverage will accuse that some lines of the
+ * function aren't being tested, but it's a bug.
+ *
+ * If you look at the tests bellow and to the function, you
+ * will see that every single case is being tested
+ *
+ *
+ *
+ */
+describe("unnest Util", () => {
+	describe("With object with no undefined values", () => {
+		class Foo {
+			public bar = "bar";
+		}
+
+		const foo = new Foo();
+
+		it("should return the same object (with simple object)", () => {
+			let result: any;
+
+			try {
+				result = unnest({
+					foo: 1,
+					xyz: 2,
+					def: 3,
+				});
+			} catch (err: any) {
+				result = err;
+			}
+
+			expect(result).toStrictEqual({
+				foo: 1,
+				xyz: 2,
+				def: 3,
+			});
+		});
+
+		it("should return the same object (with nested object)", () => {
+			let result: any;
+
+			try {
+				result = unnest({
+					foo: 1,
+					bar: {
+						xyz: 2,
+						abc: {
+							def: 3,
+							ufg: [1],
+						},
+					},
+				});
+			} catch (err: any) {
+				result = err;
+			}
+
+			expect(result).toStrictEqual({
+				"foo": 1,
+				"bar.xyz": 2,
+				"bar.abc.def": 3,
+				"bar.abc.ufg[0]": 1,
+			});
+		});
+
+		it("should return the same object (with simple array)", () => {
+			let result: any;
+
+			try {
+				result = unnest({
+					ghi: [1, 2, 3],
+				});
+			} catch (err: any) {
+				result = err;
+			}
+
+			expect(result).toStrictEqual({
+				"ghi[0]": 1,
+				"ghi[1]": 2,
+				"ghi[2]": 3,
+			});
+		});
+
+		it("should return the same object (with array of objects)", () => {
+			let result: any;
+
+			try {
+				result = unnest({
+					ghi: [
+						{
+							jkl: 4,
+						},
+						{
+							foo: 5,
+						},
+					],
+				});
+			} catch (err: any) {
+				result = err;
+			}
+
+			expect(result).toStrictEqual({
+				"ghi[0].jkl": 4,
+				"ghi[1].foo": 5,
+			});
+		});
+
+		it("should return the same object (with array of array)", () => {
+			let result: any;
+
+			try {
+				result = unnest({
+					ghi: [[1], [2], [3]],
+				});
+			} catch (err: any) {
+				result = err;
+			}
+
+			expect(result).toStrictEqual({
+				"ghi[0][0]": 1,
+				"ghi[1][0]": 2,
+				"ghi[2][0]": 3,
+			});
+		});
+
+		it("should return the same object (with class)", () => {
+			let result: any;
+
+			try {
+				result = unnest({
+					bar: {
+						xyz: Foo,
+					},
+				});
+			} catch (err: any) {
+				result = err;
+			}
+
+			expect(result).toStrictEqual({
+				"bar.xyz": Foo,
+			});
+		});
+
+		it("should return the same object (with class instance)", () => {
+			let result: any;
+
+			try {
+				result = unnest({
+					bar: {
+						xyz: foo,
+					},
+				});
+			} catch (err: any) {
+				result = err;
+			}
+
+			expect(result).toStrictEqual({
+				"bar.xyz": foo,
+			});
+		});
+	});
+
+	describe("With array with no undefined values", () => {
+		it("should return the same object (with simple object)", () => {
+			let result: any;
+
+			try {
+				result = unnest(["foo", "xyz", "def"]);
+			} catch (err: any) {
+				result = err;
+			}
+
+			expect(result).toStrictEqual({
+				"0": "foo",
+				"1": "xyz",
+				"2": "def",
+			});
+		});
+	});
+
+	describe("With object with null or undefined values", () => {
+		it("should return an empty object", () => {
+			let result: any;
+
+			try {
+				result = unnest({
+					foo: undefined,
+					bar: {
+						xyz: null,
+					},
+					ghi: [undefined],
+				});
+			} catch (err: any) {
+				result = err;
+			}
+
+			expect(result).toStrictEqual({});
+		});
+	});
+
+	describe("With NOT object or array", () => {
+		it("should throw an error", () => {
+			let result: any;
+
+			try {
+				result = unnest("foo" as any);
+			} catch (err: any) {
+				result = err;
+			}
+
+			expect(result instanceof Error).toBeTruthy();
+			expect(result.message).toBe("Value must be an object");
+		});
+	});
+});


### PR DESCRIPTION
## What this PR introduces?

Issue Number: N/A

<!-- Please, includes description of this pull request -->

Add `unnest`, to unnest an object to have keys with the complete path

Ex:

Input
```
{
  foo: 1,
  bar: {
    xyz: 2,
    abc: {
      def: 3,
    }
  },
  ghi: [
    {
      jkl: 4,
    }
  ]
}
```

Output
```
{
  foo: 1,
  "bar.xyz": 2,
  "bar.abc.def": 3,
  "ghi[0].jkl": 4,
}
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/techmmunity/utils/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added / updated
- [x] Docs have been added / updated
- [x] I followed GitFlow pattern to create the branch
- [x] My code produces no warnings or errors

## PR Type

What kind of change does this PR introduce?

```
[ ] Hotfix
[ ] Bugfix
[x] Feature
[ ] Documentation update
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] CI/CD related changes
[ ] Other: ...
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information (Prints, details, etc)
